### PR TITLE
Added groovy gradle plugin in order to enable spock framework

### DIFF
--- a/tasks.gradle
+++ b/tasks.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'java'
+apply plugin: 'groovy'
 apply plugin: 'maven-publish'
 apply plugin: 'maven'
 apply plugin: 'checkstyle'


### PR DESCRIPTION
This will enable [Spock](http://spockframework.org/) test framework. 
This PR is the first part of resolving issue: https://github.com/k0r0pt/Project-Tauro/issues/10
The second part is here: k0r0pt/Project-Tauro#21